### PR TITLE
Fix CSP to allow legacy http images to show up properly

### DIFF
--- a/MECCG/tools/MECCG-Collection-Generator.html
+++ b/MECCG/tools/MECCG-Collection-Generator.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title>MECCG Collection Generator</title>
     <script type="text/javascript">
 // adapted from https://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/

--- a/MECCG/tools/MECCG-Deck-Checker.html
+++ b/MECCG/tools/MECCG-Deck-Checker.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title>MECCG Deck Checker</title>
     <script type="text/javascript">
       

--- a/MECCG/tools/MECCG-Deck-Distinction.html
+++ b/MECCG/tools/MECCG-Deck-Distinction.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title>MECCG Deck Checker</title>
     <script type="text/javascript">
       


### PR DESCRIPTION
This should allow the broken images to show up properly based on similar issues as explained in [https://stackoverflow.com/questions/46672558/mixed-content-error-when-using-github-pages-with-custom-domain](https://stackoverflow.com/questions/46672558/mixed-content-error-when-using-github-pages-with-custom-domain)